### PR TITLE
feat: honor machinedeployments in machine apply phase

### DIFF
--- a/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go
+++ b/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go
@@ -1033,7 +1033,7 @@ func ExtractControlPlaneMachine(machines []*clusterv1.Machine) (*clusterv1.Machi
 	nodes := []*clusterv1.Machine{}
 	controlPlaneMachines := []*clusterv1.Machine{}
 	for _, machine := range machines {
-		if util.IsControlPlaneMachine(machine) {
+		if util.IsControlPlaneMachine(machine.Spec) {
 			controlPlaneMachines = append(controlPlaneMachines, machine)
 		} else {
 			nodes = append(nodes, machine)

--- a/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go
+++ b/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go
@@ -1044,3 +1044,25 @@ func ExtractControlPlaneMachine(machines []*clusterv1.Machine) (*clusterv1.Machi
 	}
 	return controlPlaneMachines[0], nodes, nil
 }
+
+// ExtractControlPlaneMachineDeployments separates machinedeployments defining control plane machines from those defining nodes.
+// This is currently done by looking at which machinedeployments specify machine templates with a control plane version
+func ExtractControlPlaneMachineDeployments(machineDeployments []*clusterv1.MachineDeployment) (*clusterv1.MachineDeployment, []*clusterv1.MachineDeployment, error) {
+	nodeDeployments := []*clusterv1.MachineDeployment{}
+	controlPlaneDeployments := []*clusterv1.MachineDeployment{}
+	for _, machineDeployment := range machineDeployments {
+		if util.IsControlPlaneMachine(machineDeployment.Spec.Template.Spec) {
+			controlPlaneDeployments = append(controlPlaneDeployments, machineDeployment)
+		} else {
+			nodeDeployments = append(nodeDeployments, machineDeployment)
+		}
+	}
+
+	if len(controlPlaneDeployments) > 1 {
+		return nil, nil, errors.Errorf("expected one or zero control plane machinedeployments, got: %v", len(controlPlaneDeployments))
+	} else if len(controlPlaneDeployments) == 1 {
+		return controlPlaneDeployments[0], nodeDeployments, nil
+	}
+
+	return nil, nodeDeployments, nil
+}

--- a/cmd/clusterctl/clusterdeployer/clusterdeployer.go
+++ b/cmd/clusterctl/clusterdeployer/clusterdeployer.go
@@ -135,8 +135,13 @@ func (d *ClusterDeployer) Create(cluster *clusterv1.Cluster, machines []*cluster
 		return errors.Wrap(err, "unable to update target cluster endpoint")
 	}
 
+	_, nodeDeployments, err := clusterclient.ExtractControlPlaneMachineDeployments(machineDeployments)
+	if err != nil {
+		return errors.Wrap(err, "unable to separate control plane machineDeployments from node machineDeployments")
+	}
+
 	klog.Info("Creating node machines in target cluster.")
-	if err := phases.ApplyMachines(targetClient, cluster.Namespace, nodes, machineDeployments); err != nil {
+	if err := phases.ApplyMachines(targetClient, cluster.Namespace, nodes, nodeDeployments); err != nil {
 		return errors.Wrap(err, "unable to create node machines")
 	}
 

--- a/cmd/clusterctl/clusterdeployer/clusterdeployer.go
+++ b/cmd/clusterctl/clusterdeployer/clusterdeployer.go
@@ -56,7 +56,7 @@ func New(
 }
 
 // Create the cluster from the provided cluster definition and machine list.
-func (d *ClusterDeployer) Create(cluster *clusterv1.Cluster, machines []*clusterv1.Machine, provider provider.Deployer, kubeconfigOutput string, providerComponentsStoreFactory provider.ComponentsStoreFactory) error {
+func (d *ClusterDeployer) Create(cluster *clusterv1.Cluster, machines []*clusterv1.Machine, machineDeployments []*clusterv1.MachineDeployment, provider provider.Deployer, kubeconfigOutput string, providerComponentsStoreFactory provider.ComponentsStoreFactory) error {
 	controlPlaneMachine, nodes, err := clusterclient.ExtractControlPlaneMachine(machines)
 	if err != nil {
 		return errors.Wrap(err, "unable to separate control plane machines from node machines")
@@ -90,7 +90,7 @@ func (d *ClusterDeployer) Create(cluster *clusterv1.Cluster, machines []*cluster
 	}
 
 	klog.Infof("Creating control plane %v in namespace %q", controlPlaneMachine.Name, cluster.Namespace)
-	if err := phases.ApplyMachines(bootstrapClient, cluster.Namespace, []*clusterv1.Machine{controlPlaneMachine}); err != nil {
+	if err := phases.ApplyMachines(bootstrapClient, cluster.Namespace, []*clusterv1.Machine{controlPlaneMachine}, []*clusterv1.MachineDeployment{}); err != nil {
 		return errors.Wrap(err, "unable to create control plane machine")
 	}
 
@@ -136,7 +136,7 @@ func (d *ClusterDeployer) Create(cluster *clusterv1.Cluster, machines []*cluster
 	}
 
 	klog.Info("Creating node machines in target cluster.")
-	if err := phases.ApplyMachines(targetClient, cluster.Namespace, nodes); err != nil {
+	if err := phases.ApplyMachines(targetClient, cluster.Namespace, nodes, machineDeployments); err != nil {
 		return errors.Wrap(err, "unable to create node machines")
 	}
 

--- a/cmd/clusterctl/clusterdeployer/clusterdeployer_test.go
+++ b/cmd/clusterctl/clusterdeployer/clusterdeployer_test.go
@@ -860,6 +860,7 @@ func TestClusterCreate(t *testing.T) {
 			d := New(p, f, "", "", bootstrapComponent, testcase.cleanupExternal)
 
 			inputMachines := make(map[string][]*clusterv1.Machine)
+			inputMachineDeployments := make(map[string][]*clusterv1.MachineDeployment)
 
 			for namespace, inputClusters := range testcase.namespaceToInputCluster {
 				ns := namespace
@@ -871,7 +872,9 @@ func TestClusterCreate(t *testing.T) {
 				for _, inputCluster := range inputClusters {
 					inputCluster.Name = fmt.Sprintf("%s-cluster", ns)
 					inputMachines[inputCluster.Name] = generateMachines(inputCluster, ns)
-					err = d.Create(inputCluster, inputMachines[inputCluster.Name], pd, kubeconfigOut, &pcFactory)
+					inputMachineDeployments[inputCluster.Name] = generateMachineDeployments(inputCluster, ns)
+
+					err = d.Create(inputCluster, inputMachines[inputCluster.Name], inputMachineDeployments[inputCluster.Name], pd, kubeconfigOut, &pcFactory)
 					if err != nil {
 						break
 					}
@@ -969,11 +972,12 @@ func TestCreateProviderComponentsScenarios(t *testing.T) {
 				},
 			}
 			inputMachines := generateMachines(inputCluster, metav1.NamespaceDefault)
+			inputMachineDeployments := generateMachineDeployments(inputCluster, metav1.NamespaceDefault)
 			pcFactory := mockProviderComponentsStoreFactory{NewFromCoreclientsetPCStore: &tc.pcStore}
 			providerComponentsYaml := "---\nyaml: definition"
 			addonsYaml := "---\nyaml: definition"
 			d := New(p, f, providerComponentsYaml, addonsYaml, "", false)
-			err := d.Create(inputCluster, inputMachines, pd, kubeconfigOut, &pcFactory)
+			err := d.Create(inputCluster, inputMachines, inputMachineDeployments, pd, kubeconfigOut, &pcFactory)
 			if err == nil && tc.expectedError != "" {
 				t.Fatalf("error mismatch: got '%v', want '%v'", err, tc.expectedError)
 			}
@@ -1465,6 +1469,27 @@ func generateTestNodeMachine(cluster *clusterv1.Cluster, ns, name string) *clust
 	return &machine
 }
 
+func generateTestNodeMachineDeployment(cluster *clusterv1.Cluster, ns, name string) *clusterv1.MachineDeployment {
+	machineDeployment := clusterv1.MachineDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+	}
+	if cluster != nil {
+		machineDeployment.Labels = map[string]string{clusterv1.MachineClusterLabelName: cluster.Name}
+		machineDeployment.OwnerReferences = []metav1.OwnerReference{
+			{
+				APIVersion: cluster.APIVersion,
+				Kind:       cluster.Kind,
+				Name:       cluster.Name,
+				UID:        cluster.UID,
+			},
+		}
+	}
+	return &machineDeployment
+}
+
 func generateTestNodeMachines(cluster *clusterv1.Cluster, ns string, nodeNames []string) []*clusterv1.Machine {
 	nodes := make([]*clusterv1.Machine, 0, len(nodeNames))
 	for _, nn := range nodeNames {
@@ -1500,6 +1525,16 @@ func generateMachines(cluster *clusterv1.Cluster, ns string) []*clusterv1.Machin
 	machines = append(machines, generateTestControlPlaneMachine(cluster, ns, controlPlaneName))
 	machines = append(machines, generateTestNodeMachine(cluster, ns, workerName))
 	return machines
+}
+
+func generateMachineDeployments(cluster *clusterv1.Cluster, ns string) []*clusterv1.MachineDeployment {
+	var machineDeployments []*clusterv1.MachineDeployment
+	deploymentName := "node-deployment"
+	if cluster != nil {
+		deploymentName = cluster.Name + deploymentName
+	}
+	machineDeployments = append(machineDeployments, generateTestNodeMachineDeployment(cluster, ns, deploymentName))
+	return machineDeployments
 }
 
 func newMachineSetsFixture(ns string) []*clusterv1.MachineSet {

--- a/cmd/clusterctl/cmd/alpha_phase_apply_machines.go
+++ b/cmd/clusterctl/cmd/alpha_phase_apply_machines.go
@@ -60,7 +60,12 @@ func RunAlphaPhaseApplyMachines(pamo *AlphaPhaseApplyMachinesOptions) error {
 		return err
 	}
 
-	machines, machineDeployments, err := util.ParseMachinesYaml(pamo.Machines)
+	machines, err := util.ParseMachinesYaml(pamo.Machines)
+	if err != nil {
+		return err
+	}
+
+	machineDeployments, err := util.ParseMachineDeploymentYaml(pamo.Machines)
 	if err != nil {
 		return err
 	}

--- a/cmd/clusterctl/cmd/alpha_phase_apply_machines.go
+++ b/cmd/clusterctl/cmd/alpha_phase_apply_machines.go
@@ -60,7 +60,7 @@ func RunAlphaPhaseApplyMachines(pamo *AlphaPhaseApplyMachinesOptions) error {
 		return err
 	}
 
-	machines, err := util.ParseMachinesYaml(pamo.Machines)
+	machines, machineDeployments, err := util.ParseMachinesYaml(pamo.Machines)
 	if err != nil {
 		return err
 	}
@@ -71,7 +71,7 @@ func RunAlphaPhaseApplyMachines(pamo *AlphaPhaseApplyMachinesOptions) error {
 		return errors.Wrap(err, "unable to create cluster client")
 	}
 
-	if err := phases.ApplyMachines(client, pamo.Namespace, machines); err != nil {
+	if err := phases.ApplyMachines(client, pamo.Namespace, machines, machineDeployments); err != nil {
 		return errors.Wrap(err, "unable to apply machines")
 	}
 

--- a/cmd/clusterctl/cmd/create_cluster.go
+++ b/cmd/clusterctl/cmd/create_cluster.go
@@ -68,7 +68,7 @@ func RunCreate(co *CreateOptions) error {
 	if err != nil {
 		return err
 	}
-	m, err := util.ParseMachinesYaml(co.Machine)
+	m, md, err := util.ParseMachinesYaml(co.Machine)
 	if err != nil {
 		return err
 	}
@@ -109,7 +109,7 @@ func RunCreate(co *CreateOptions) error {
 		string(bc),
 		co.BootstrapFlags.Cleanup)
 
-	return d.Create(c, m, pd, co.KubeconfigOutput, pcsFactory)
+	return d.Create(c, m, md, pd, co.KubeconfigOutput, pcsFactory)
 }
 
 func init() {

--- a/cmd/clusterctl/cmd/create_cluster.go
+++ b/cmd/clusterctl/cmd/create_cluster.go
@@ -68,7 +68,11 @@ func RunCreate(co *CreateOptions) error {
 	if err != nil {
 		return err
 	}
-	m, md, err := util.ParseMachinesYaml(co.Machine)
+	m, err := util.ParseMachinesYaml(co.Machine)
+	if err != nil {
+		return err
+	}
+	md, err := util.ParseMachineDeploymentYaml(co.Machine)
 	if err != nil {
 		return err
 	}

--- a/cmd/clusterctl/phases/applymachines.go
+++ b/cmd/clusterctl/phases/applymachines.go
@@ -23,7 +23,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
 
-func ApplyMachines(client clusterclient.Client, namespace string, machines []*clusterv1.Machine) error {
+func ApplyMachines(client clusterclient.Client, namespace string, machines []*clusterv1.Machine, machineDeployments []*clusterv1.MachineDeployment) error {
 	if namespace == "" {
 		namespace = client.GetContextNamespace()
 	}
@@ -35,6 +35,11 @@ func ApplyMachines(client clusterclient.Client, namespace string, machines []*cl
 
 	klog.Infof("Creating machines in namespace %q", namespace)
 	if err := client.CreateMachines(machines, namespace); err != nil {
+		return err
+	}
+
+	klog.Infof("Creating machinedeployments in namespace %q", namespace)
+	if err := client.CreateMachineDeployments(machineDeployments, namespace); err != nil {
 		return err
 	}
 

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -41,6 +41,18 @@ kind: Machine
 metadata:
   name: machine2`
 
+const validMachineDeployments1 = `
+---
+apiVersion: "cluster.k8s.io/v1alpha1"
+kind: MachineDeployment
+metadata:
+  name: machinedeployment1
+---
+apiVersion: "cluster.k8s.io/v1alpha1"
+kind: MachineDeployment
+metadata:
+  name: machinedeployment2`
+
 const validUnified1 = `
 apiVersion: "cluster.k8s.io/v1alpha1"
 kind: Cluster
@@ -69,7 +81,12 @@ metadata:
 apiVersion: "cluster.k8s.io/v1alpha1"
 kind: Machine
 metadata:
-  name: machine2`
+  name: machine2
+---
+apiVersion: "cluster.k8s.io/v1alpha1"
+kind: MachineDeployment
+metadata:
+  name: machinedeployment1`
 
 const validUnified3 = `
 apiVersion: v1
@@ -243,36 +260,47 @@ func TestParseClusterYaml(t *testing.T) {
 
 func TestParseMachineYaml(t *testing.T) {
 	t.Run("File does not exist", func(t *testing.T) {
-		_, err := ParseMachinesYaml("fileDoesNotExist")
+		_, _, err := ParseMachinesYaml("fileDoesNotExist")
 		if err == nil {
 			t.Fatal("Was able to parse a file that does not exist")
 		}
 	})
 	var testcases = []struct {
-		name                 string
-		contents             string
-		expectErr            bool
-		expectedMachineCount int
+		name                           string
+		contents                       string
+		expectErr                      bool
+		expectedMachineCount           int
+		expectedMachineDeploymentCount int
 	}{
 		{
-			name:                 "valid file using Machines",
-			contents:             validMachines1,
-			expectedMachineCount: 2,
+			name:                           "valid file using Machines",
+			contents:                       validMachines1,
+			expectedMachineCount:           2,
+			expectedMachineDeploymentCount: 0,
 		},
 		{
-			name:                 "valid unified file with machine list",
-			contents:             validUnified1,
-			expectedMachineCount: 1,
+			name:                           "valid file using MachineDeployments",
+			contents:                       validMachineDeployments1,
+			expectedMachineCount:           0,
+			expectedMachineDeploymentCount: 2,
 		},
 		{
-			name:                 "valid unified file with separate machines",
-			contents:             validUnified2,
-			expectedMachineCount: 2,
+			name:                           "valid unified file with machine list",
+			contents:                       validUnified1,
+			expectedMachineCount:           1,
+			expectedMachineDeploymentCount: 0,
 		},
 		{
-			name:                 "valid unified file with separate machines and a configmap",
-			contents:             validUnified3,
-			expectedMachineCount: 2,
+			name:                           "valid unified file with separate machines",
+			contents:                       validUnified2,
+			expectedMachineCount:           2,
+			expectedMachineDeploymentCount: 1,
+		},
+		{
+			name:                           "valid unified file with separate machines and a configmap",
+			contents:                       validUnified3,
+			expectedMachineCount:           2,
+			expectedMachineDeploymentCount: 0,
 		},
 		{
 			name:      "invalid file using MachineList",
@@ -308,7 +336,7 @@ func TestParseMachineYaml(t *testing.T) {
 			}
 			defer os.Remove(file)
 
-			m, err := ParseMachinesYaml(file)
+			m, md, err := ParseMachinesYaml(file)
 			if (testcase.expectErr && err == nil) || (!testcase.expectErr && err != nil) {
 				t.Fatalf("Unexpected returned error. Got: %v, Want Err: %v", err, testcase.expectErr)
 			}
@@ -320,6 +348,9 @@ func TestParseMachineYaml(t *testing.T) {
 			}
 			if len(m) != testcase.expectedMachineCount {
 				t.Fatalf("Unexpected machine count. Got: %v, Want: %v", len(m), testcase.expectedMachineCount)
+			}
+			if len(md) != testcase.expectedMachineDeploymentCount {
+				t.Fatalf("Unexpected machinedeployment count. Got: %v, Want: %v", len(m), testcase.expectedMachineDeploymentCount)
 			}
 		})
 	}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -260,47 +260,41 @@ func TestParseClusterYaml(t *testing.T) {
 
 func TestParseMachineYaml(t *testing.T) {
 	t.Run("File does not exist", func(t *testing.T) {
-		_, _, err := ParseMachinesYaml("fileDoesNotExist")
+		_, err := ParseMachinesYaml("fileDoesNotExist")
 		if err == nil {
 			t.Fatal("Was able to parse a file that does not exist")
 		}
 	})
 	var testcases = []struct {
-		name                           string
-		contents                       string
-		expectErr                      bool
-		expectedMachineCount           int
-		expectedMachineDeploymentCount int
+		name                 string
+		contents             string
+		expectErr            bool
+		expectedMachineCount int
 	}{
 		{
-			name:                           "valid file using Machines",
-			contents:                       validMachines1,
-			expectedMachineCount:           2,
-			expectedMachineDeploymentCount: 0,
+			name:                 "valid file using Machines",
+			contents:             validMachines1,
+			expectedMachineCount: 2,
 		},
 		{
-			name:                           "valid file using MachineDeployments",
-			contents:                       validMachineDeployments1,
-			expectedMachineCount:           0,
-			expectedMachineDeploymentCount: 2,
+			name:                 "valid file using MachineDeployments",
+			contents:             validMachineDeployments1,
+			expectedMachineCount: 0,
 		},
 		{
-			name:                           "valid unified file with machine list",
-			contents:                       validUnified1,
-			expectedMachineCount:           1,
-			expectedMachineDeploymentCount: 0,
+			name:                 "valid unified file with machine list",
+			contents:             validUnified1,
+			expectedMachineCount: 1,
 		},
 		{
-			name:                           "valid unified file with separate machines",
-			contents:                       validUnified2,
-			expectedMachineCount:           2,
-			expectedMachineDeploymentCount: 1,
+			name:                 "valid unified file with separate machines",
+			contents:             validUnified2,
+			expectedMachineCount: 2,
 		},
 		{
-			name:                           "valid unified file with separate machines and a configmap",
-			contents:                       validUnified3,
-			expectedMachineCount:           2,
-			expectedMachineDeploymentCount: 0,
+			name:                 "valid unified file with separate machines and a configmap",
+			contents:             validUnified3,
+			expectedMachineCount: 2,
 		},
 		{
 			name:      "invalid file using MachineList",
@@ -336,7 +330,7 @@ func TestParseMachineYaml(t *testing.T) {
 			}
 			defer os.Remove(file)
 
-			m, md, err := ParseMachinesYaml(file)
+			m, err := ParseMachinesYaml(file)
 			if (testcase.expectErr && err == nil) || (!testcase.expectErr && err != nil) {
 				t.Fatalf("Unexpected returned error. Got: %v, Want Err: %v", err, testcase.expectErr)
 			}
@@ -349,8 +343,59 @@ func TestParseMachineYaml(t *testing.T) {
 			if len(m) != testcase.expectedMachineCount {
 				t.Fatalf("Unexpected machine count. Got: %v, Want: %v", len(m), testcase.expectedMachineCount)
 			}
+		})
+	}
+}
+
+func TestParseMachineDeploymentYaml(t *testing.T) {
+	t.Run("File does not exist", func(t *testing.T) {
+		_, err := ParseMachineDeploymentYaml("fileDoesNotExist")
+		if err == nil {
+			t.Fatal("Was able to parse a file that does not exist")
+		}
+	})
+	var testcases = []struct {
+		name                           string
+		contents                       string
+		expectErr                      bool
+		expectedMachineDeploymentCount int
+	}{
+		{
+			name:                           "valid file using MachineDeployments",
+			contents:                       validMachineDeployments1,
+			expectedMachineDeploymentCount: 2,
+		},
+		{
+			name:                           "valid unified file with separate machines",
+			contents:                       validUnified2,
+			expectedMachineDeploymentCount: 1,
+		},
+		{
+			name:      "gibberish in file",
+			contents:  `!@#blah ` + validMachines1 + ` blah!@#`,
+			expectErr: true,
+		},
+	}
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			file, err := createTempFile(testcase.contents)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.Remove(file)
+
+			md, err := ParseMachineDeploymentYaml(file)
+			if (testcase.expectErr && err == nil) || (!testcase.expectErr && err != nil) {
+				t.Fatalf("Unexpected returned error. Got: %v, Want Err: %v", err, testcase.expectErr)
+			}
+			if err != nil {
+				return
+			}
+			if md == nil {
+				t.Fatalf("No machinedeployments returned in success case.")
+			}
 			if len(md) != testcase.expectedMachineDeploymentCount {
-				t.Fatalf("Unexpected machinedeployment count. Got: %v, Want: %v", len(m), testcase.expectedMachineDeploymentCount)
+				t.Fatalf("Unexpected machinedeployment count. Got: %v, Want: %v", len(md), testcase.expectedMachineDeploymentCount)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

The `apply-machines` phase will now detect and apply MachineDeployments as nodes, and therefore, so will `clusterctl create cluster`.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support MachineDeployments as part of the apply-machines phase
```
