### PR TITLE
[WiP] Ability to deploy multiple controlplane machines (HA)

### DIFF
--- a/cmd/clusterctl/clusterdeployer/clusterdeployer.go
+++ b/cmd/clusterctl/clusterdeployer/clusterdeployer.go
@@ -56,8 +56,8 @@ func New(
 }
 
 // Create the cluster from the provided cluster definition and machine list.
-func (d *ClusterDeployer) Create(cluster *clusterv1.Cluster, machines []*clusterv1.Machine, provider provider.Deployer, kubeconfigOutput string, providerComponentsStoreFactory provider.ComponentsStoreFactory) error {
-	controlPlaneMachine, nodes, err := clusterclient.ExtractControlPlaneMachine(machines)
+func (d *ClusterDeployer) Create(cluster *clusterv1.Cluster, machines []*clusterv1.Machine, machineDeployments []*clusterv1.MachineDeployment, provider provider.Deployer, kubeconfigOutput string, providerComponentsStoreFactory provider.ComponentsStoreFactory) error {
+	controlPlaneMachines, nodes, err := clusterclient.ExtractControlPlaneMachines(machines)
 	if err != nil {
 		return errors.Wrap(err, "unable to separate control plane machines from node machines")
 	}
@@ -89,12 +89,12 @@ func (d *ClusterDeployer) Create(cluster *clusterv1.Cluster, machines []*cluster
 		cluster.Namespace = bootstrapClient.GetContextNamespace()
 	}
 
-	klog.Infof("Creating control plane %v in namespace %q", controlPlaneMachine.Name, cluster.Namespace)
-	if err := phases.ApplyMachines(bootstrapClient, cluster.Namespace, []*clusterv1.Machine{controlPlaneMachine}); err != nil {
+	klog.Infof("Creating control plane %v in namespace %q", controlPlaneMachines[0].Name, cluster.Namespace)
+	if err := phases.ApplyMachines(bootstrapClient, cluster.Namespace, []*clusterv1.Machine{controlPlaneMachines[0]}, []*clusterv1.MachineDeployment{}); err != nil {
 		return errors.Wrap(err, "unable to create control plane machine")
 	}
 
-	klog.Infof("Updating bootstrap cluster object for cluster %v in namespace %q with control plane endpoint running on %s", cluster.Name, cluster.Namespace, controlPlaneMachine.Name)
+	klog.Infof("Updating bootstrap cluster object for cluster %v in namespace %q with control plane endpoint running on %s", cluster.Name, cluster.Namespace, controlPlaneMachines[0].Name)
 	if err := d.updateClusterEndpoint(bootstrapClient, provider, cluster.Name, cluster.Namespace); err != nil {
 		return errors.Wrap(err, "unable to update bootstrap cluster endpoint")
 	}
@@ -130,13 +130,25 @@ func (d *ClusterDeployer) Create(cluster *clusterv1.Cluster, machines []*cluster
 
 	// For some reason, endpoint doesn't get updated in bootstrap cluster sometimes. So we
 	// update the target cluster endpoint as well to be sure.
-	klog.Infof("Updating target cluster object with control plane endpoint running on %s", controlPlaneMachine.Name)
+	klog.Infof("Updating target cluster object with control plane endpoint running on %s", controlPlaneMachines[0].Name)
 	if err := d.updateClusterEndpoint(targetClient, provider, cluster.Name, cluster.Namespace); err != nil {
 		return errors.Wrap(err, "unable to update target cluster endpoint")
 	}
 
+	_, nodeDeployments, err := clusterclient.ExtractControlPlaneMachineDeployments(machineDeployments)
+	if err != nil {
+		return errors.Wrap(err, "unable to separate control plane machineDeployments from node machineDeployments")
+	}
+
+	if len(controlPlaneMachines) > 1 {
+		klog.Info("Creating additional controlplane machines in target cluster.")
+		if err := phases.ApplyMachines(targetClient, cluster.Namespace, controlPlaneMachines[1:], []*clusterv1.MachineDeployment{}); err != nil {
+			return errors.Wrap(err, "unable to create additional controlplane machines")
+		}
+	}
+
 	klog.Info("Creating node machines in target cluster.")
-	if err := phases.ApplyMachines(targetClient, cluster.Namespace, nodes); err != nil {
+	if err := phases.ApplyMachines(targetClient, cluster.Namespace, nodes, nodeDeployments); err != nil {
 		return errors.Wrap(err, "unable to create node machines")
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
It adds the ability to deploy multiple controlplane machines.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Clusterctl can deploy multiple controlplane machines.
```
