### PR TITLE
Rudoi/honor machinedeployments in machine phase

### DIFF
--- a/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go
+++ b/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go
@@ -1057,3 +1057,25 @@ func ExtractControlPlaneMachines(machines []*clusterv1.Machine) ([]*clusterv1.Ma
 	}
 	return controlPlaneMachines, nodes, nil
 }
+
+// ExtractControlPlaneMachineDeployments separates machinedeployments defining control plane machines from those defining nodes.
+// This is currently done by looking at which machinedeployments specify machine templates with a control plane version
+func ExtractControlPlaneMachineDeployments(machineDeployments []*clusterv1.MachineDeployment) (*clusterv1.MachineDeployment, []*clusterv1.MachineDeployment, error) {
+	nodeDeployments := []*clusterv1.MachineDeployment{}
+	controlPlaneDeployments := []*clusterv1.MachineDeployment{}
+	for _, machineDeployment := range machineDeployments {
+		if util.IsControlPlaneMachine(machineDeployment.Spec.Template.Spec) {
+			controlPlaneDeployments = append(controlPlaneDeployments, machineDeployment)
+		} else {
+			nodeDeployments = append(nodeDeployments, machineDeployment)
+		}
+	}
+
+	if len(controlPlaneDeployments) > 1 {
+		return nil, nil, errors.Errorf("expected one or zero control plane machinedeployments, got: %v", len(controlPlaneDeployments))
+	} else if len(controlPlaneDeployments) == 1 {
+		return controlPlaneDeployments[0], nodeDeployments, nil
+	}
+
+	return nil, nodeDeployments, nil
+}

--- a/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go
+++ b/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go
@@ -1046,7 +1046,7 @@ func ExtractControlPlaneMachines(machines []*clusterv1.Machine) ([]*clusterv1.Ma
 	nodes := []*clusterv1.Machine{}
 	controlPlaneMachines := []*clusterv1.Machine{}
 	for _, machine := range machines {
-		if util.IsControlPlaneMachine(machine.Spec) {
+		if util.IsControlPlaneMachine(machine) {
 			controlPlaneMachines = append(controlPlaneMachines, machine)
 		} else {
 			nodes = append(nodes, machine)
@@ -1064,7 +1064,7 @@ func ExtractControlPlaneMachineDeployments(machineDeployments []*clusterv1.Machi
 	nodeDeployments := []*clusterv1.MachineDeployment{}
 	controlPlaneDeployments := []*clusterv1.MachineDeployment{}
 	for _, machineDeployment := range machineDeployments {
-		if util.IsControlPlaneMachine(machineDeployment.Spec.Template.Spec) {
+		if util.IsControlPlaneMachineDeployment(machineDeployment) {
 			controlPlaneDeployments = append(controlPlaneDeployments, machineDeployment)
 		} else {
 			nodeDeployments = append(nodeDeployments, machineDeployment)

--- a/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go
+++ b/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go
@@ -1046,7 +1046,7 @@ func ExtractControlPlaneMachines(machines []*clusterv1.Machine) ([]*clusterv1.Ma
 	nodes := []*clusterv1.Machine{}
 	controlPlaneMachines := []*clusterv1.Machine{}
 	for _, machine := range machines {
-		if util.IsControlPlaneMachine(machine) {
+		if util.IsControlPlaneMachine(machine.Spec) {
 			controlPlaneMachines = append(controlPlaneMachines, machine)
 		} else {
 			nodes = append(nodes, machine)

--- a/cmd/clusterctl/clusterdeployer/clusterdeployer.go
+++ b/cmd/clusterctl/clusterdeployer/clusterdeployer.go
@@ -146,8 +146,13 @@ func (d *ClusterDeployer) Create(cluster *clusterv1.Cluster, machines []*cluster
 		}
 	}
 
+	_, nodeDeployments, err := clusterclient.ExtractControlPlaneMachineDeployments(machineDeployments)
+	if err != nil {
+		return errors.Wrap(err, "unable to separate control plane machineDeployments from node machineDeployments")
+	}
+
 	klog.Info("Creating node machines in target cluster.")
-	if err := phases.ApplyMachines(targetClient, cluster.Namespace, nodes, machineDeployments); err != nil {
+	if err := phases.ApplyMachines(targetClient, cluster.Namespace, nodes, nodeDeployments); err != nil {
 		return errors.Wrap(err, "unable to create node machines")
 	}
 

--- a/cmd/clusterctl/clusterdeployer/clusterdeployer.go
+++ b/cmd/clusterctl/clusterdeployer/clusterdeployer.go
@@ -56,7 +56,7 @@ func New(
 }
 
 // Create the cluster from the provided cluster definition and machine list.
-func (d *ClusterDeployer) Create(cluster *clusterv1.Cluster, machines []*clusterv1.Machine, provider provider.Deployer, kubeconfigOutput string, providerComponentsStoreFactory provider.ComponentsStoreFactory) error {
+func (d *ClusterDeployer) Create(cluster *clusterv1.Cluster, machines []*clusterv1.Machine, machineDeployments []*clusterv1.MachineDeployment, provider provider.Deployer, kubeconfigOutput string, providerComponentsStoreFactory provider.ComponentsStoreFactory) error {
 	controlPlaneMachines, nodes, err := clusterclient.ExtractControlPlaneMachines(machines)
 	if err != nil {
 		return errors.Wrap(err, "unable to separate control plane machines from node machines")
@@ -90,7 +90,7 @@ func (d *ClusterDeployer) Create(cluster *clusterv1.Cluster, machines []*cluster
 	}
 
 	klog.Infof("Creating control plane %v in namespace %q", controlPlaneMachines[0].Name, cluster.Namespace)
-	if err := phases.ApplyMachines(bootstrapClient, cluster.Namespace, []*clusterv1.Machine{controlPlaneMachines[0]}); err != nil {
+	if err := phases.ApplyMachines(bootstrapClient, cluster.Namespace, []*clusterv1.Machine{controlPlaneMachines[0]}, machineDeployments); err != nil {
 		return errors.Wrap(err, "unable to create control plane machine")
 	}
 
@@ -140,14 +140,14 @@ func (d *ClusterDeployer) Create(cluster *clusterv1.Cluster, machines []*cluster
 		// supported versions of k8s we are deploying (using kubeadm) have the fix.
 		klog.Info("Creating additional control plane machines in target cluster.")
 		for _, controlPlaneMachine := range controlPlaneMachines[1:] {
-			if err := phases.ApplyMachines(targetClient, cluster.Namespace, []*clusterv1.Machine{controlPlaneMachine}); err != nil {
+			if err := phases.ApplyMachines(targetClient, cluster.Namespace, []*clusterv1.Machine{controlPlaneMachine}, []*clusterv1.MachineDeployment{}); err != nil {
 				return errors.Wrap(err, "unable to create additional control plane machines")
 			}
 		}
 	}
 
 	klog.Info("Creating node machines in target cluster.")
-	if err := phases.ApplyMachines(targetClient, cluster.Namespace, nodes); err != nil {
+	if err := phases.ApplyMachines(targetClient, cluster.Namespace, nodes, machineDeployments); err != nil {
 		return errors.Wrap(err, "unable to create node machines")
 	}
 

--- a/cmd/clusterctl/clusterdeployer/clusterdeployer.go
+++ b/cmd/clusterctl/clusterdeployer/clusterdeployer.go
@@ -90,7 +90,7 @@ func (d *ClusterDeployer) Create(cluster *clusterv1.Cluster, machines []*cluster
 	}
 
 	klog.Infof("Creating control plane %v in namespace %q", controlPlaneMachines[0].Name, cluster.Namespace)
-	if err := phases.ApplyMachines(bootstrapClient, cluster.Namespace, []*clusterv1.Machine{controlPlaneMachines[0]}, machineDeployments); err != nil {
+	if err := phases.ApplyMachines(bootstrapClient, cluster.Namespace, []*clusterv1.Machine{controlPlaneMachines[0]}, []*clusterv1.MachineDeployment{}); err != nil {
 		return errors.Wrap(err, "unable to create control plane machine")
 	}
 

--- a/cmd/clusterctl/clusterdeployer/clusterdeployer_test.go
+++ b/cmd/clusterctl/clusterdeployer/clusterdeployer_test.go
@@ -1578,15 +1578,15 @@ func generateTestNodeMachineDeployments(cluster *clusterv1.Cluster, ns string, n
 func generateInvalidExtractControlPlaneMachine(cluster *clusterv1.Cluster, ns string, controlPlaneNames, nodeNames []string) []*clusterv1.Machine {
 	var machines []*clusterv1.Machine // nolint
 	for _, name := range controlPlaneNames {
-		machines = append(machines, generateTestControlPlaneMachine(cluster, ns, name))
+		machines = append(machines, generateTestControlPlaneMachines(cluster, ns, []string{name})...)
 	}
 	machines = append(machines, generateTestNodeMachines(cluster, ns, nodeNames)...)
 	return machines
 }
 
-func generateValidExtractControlPlaneMachineInput(cluster *clusterv1.Cluster, ns, controlPlaneName string, nodeNames []string) []*clusterv1.Machine {
+func generateValidExtractControlPlaneMachineInput(cluster *clusterv1.Cluster, ns string, controlPlaneNames, nodeNames []string) []*clusterv1.Machine {
 	var machines []*clusterv1.Machine
-	machines = append(machines, generateTestControlPlaneMachines(cluster, ns, controlPlaneName)...)
+	machines = append(machines, generateTestControlPlaneMachines(cluster, ns, controlPlaneNames)...)
 	machines = append(machines, generateTestNodeMachines(cluster, ns, nodeNames)...)
 	return machines
 }

--- a/cmd/clusterctl/clusterdeployer/clusterdeployer_test.go
+++ b/cmd/clusterctl/clusterdeployer/clusterdeployer_test.go
@@ -1053,6 +1053,65 @@ func TestExtractControlPlaneMachine(t *testing.T) {
 	}
 }
 
+func TestExtractControlPlaneMachineDeployments(t *testing.T) {
+	const singleControlPlaneName = "test-control-plane"
+	multipleControlPlaneNames := []string{"test-control-plane-1", "test-control-plane-2"}
+	const singleNodeDeploymentName = "test-nodes"
+	multipleNodeDeploymentNames := []string{"test-nodes-1", "test-nodes-2", "test-nodes-3"}
+
+	testCases := []struct {
+		name                    string
+		inputMachineDeployments []*clusterv1.MachineDeployment
+		expectedControlPlane    *clusterv1.MachineDeployment
+		expectedNodes           []*clusterv1.MachineDeployment
+		expectedError           error
+	}{
+		{
+			name:                    "success_1_control_plane_1_node",
+			inputMachineDeployments: generateMachineDeployments(nil, metav1.NamespaceDefault),
+			expectedControlPlane:    generateTestControlPlaneMachineDeployment(nil, metav1.NamespaceDefault, singleControlPlaneName),
+			expectedNodes:           generateTestNodeMachineDeployments(nil, metav1.NamespaceDefault, []string{singleNodeDeploymentName}),
+			expectedError:           nil,
+		},
+		{
+			name:                    "success_1_control_plane_multiple_nodes",
+			inputMachineDeployments: generateValidExtractControlPlaneMachineDeploymentInput(nil, metav1.NamespaceDefault, singleControlPlaneName, multipleNodeDeploymentNames),
+			expectedControlPlane:    generateTestControlPlaneMachineDeployment(nil, metav1.NamespaceDefault, singleControlPlaneName),
+			expectedNodes:           generateTestNodeMachineDeployments(nil, metav1.NamespaceDefault, multipleNodeDeploymentNames),
+			expectedError:           nil,
+		},
+		{
+			name:                    "fail_more_than_1_control_plane_not_allowed",
+			inputMachineDeployments: generateInvalidExtractControlPlaneMachineDeployment(nil, metav1.NamespaceDefault, multipleControlPlaneNames, multipleNodeDeploymentNames),
+			expectedControlPlane:    nil,
+			expectedNodes:           nil,
+			expectedError:           errors.New("expected one or zero control plane machinedeployments, got: 2"),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualControlPlane, actualNodes, actualError := clusterclient.ExtractControlPlaneMachineDeployments(tc.inputMachineDeployments)
+
+			if tc.expectedError == nil && actualError != nil {
+				t.Fatalf("%s: extractControlPlaneMachine(%q): gotError %q; wantError [nil]", tc.name, len(tc.inputMachineDeployments), actualError)
+			}
+
+			if tc.expectedError != nil && tc.expectedError.Error() != actualError.Error() {
+				t.Fatalf("%s: extractControlPlaneMachine(%q): gotError %q; wantError %q", tc.name, len(tc.inputMachineDeployments), actualError, tc.expectedError)
+			}
+
+			if (tc.expectedControlPlane == nil && actualControlPlane != nil) ||
+				(tc.expectedControlPlane != nil && actualControlPlane == nil) {
+				t.Fatalf("%s: extractControlPlaneMachine(%q): gotControlPlane = %v; wantControlPlane = %v", tc.name, len(tc.inputMachineDeployments), actualControlPlane != nil, tc.expectedControlPlane != nil)
+			}
+
+			if len(tc.expectedNodes) != len(actualNodes) {
+				t.Fatalf("%s: extractControlPlaneMachine(%q): gotNodes = %q; wantNodes = %q", tc.name, len(tc.inputMachineDeployments), len(actualNodes), len(tc.expectedNodes))
+			}
+		})
+	}
+}
+
 func TestDeleteCleanupExternalCluster(t *testing.T) {
 	const bootstrapKubeconfig = "bootstrap"
 	const targetKubeconfig = "target"
@@ -1448,6 +1507,16 @@ func generateTestControlPlaneMachines(cluster *clusterv1.Cluster, ns string, nam
 	return machines
 }
 
+func generateTestControlPlaneMachineDeployment(cluster *clusterv1.Cluster, ns, name string) *clusterv1.MachineDeployment {
+	machineDeployment := generateTestNodeMachineDeployment(cluster, ns, name)
+	machineDeployment.Spec.Template.Spec = clusterv1.MachineSpec{
+		Versions: clusterv1.MachineVersionInfo{
+			ControlPlane: "1.10.1",
+		},
+	}
+	return machineDeployment
+}
+
 func generateTestNodeMachine(cluster *clusterv1.Cluster, ns, name string) *clusterv1.Machine {
 	machine := clusterv1.Machine{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1498,11 +1567,44 @@ func generateTestNodeMachines(cluster *clusterv1.Cluster, ns string, nodeNames [
 	return nodes
 }
 
-func generateValidExtractControlPlaneMachineInput(cluster *clusterv1.Cluster, ns string, controlPlaneName []string, nodeNames []string) []*clusterv1.Machine {
+func generateTestNodeMachineDeployments(cluster *clusterv1.Cluster, ns string, nodeDeploymentNames []string) []*clusterv1.MachineDeployment {
+	nodeDeployments := make([]*clusterv1.MachineDeployment, 0, len(nodeDeploymentNames))
+	for _, ndn := range nodeDeploymentNames {
+		nodeDeployments = append(nodeDeployments, generateTestNodeMachineDeployment(cluster, ns, ndn))
+	}
+	return nodeDeployments
+}
+
+func generateInvalidExtractControlPlaneMachine(cluster *clusterv1.Cluster, ns string, controlPlaneNames, nodeNames []string) []*clusterv1.Machine {
+	var machines []*clusterv1.Machine // nolint
+	for _, name := range controlPlaneNames {
+		machines = append(machines, generateTestControlPlaneMachine(cluster, ns, name))
+	}
+	machines = append(machines, generateTestNodeMachines(cluster, ns, nodeNames)...)
+	return machines
+}
+
+func generateValidExtractControlPlaneMachineInput(cluster *clusterv1.Cluster, ns, controlPlaneName string, nodeNames []string) []*clusterv1.Machine {
 	var machines []*clusterv1.Machine
 	machines = append(machines, generateTestControlPlaneMachines(cluster, ns, controlPlaneName)...)
 	machines = append(machines, generateTestNodeMachines(cluster, ns, nodeNames)...)
 	return machines
+}
+
+func generateInvalidExtractControlPlaneMachineDeployment(cluster *clusterv1.Cluster, ns string, controlPlaneNames, nodeDeploymentNames []string) []*clusterv1.MachineDeployment {
+	var machineDeployments []*clusterv1.MachineDeployment
+	for _, name := range controlPlaneNames {
+		machineDeployments = append(machineDeployments, generateTestControlPlaneMachineDeployment(cluster, ns, name))
+	}
+	machineDeployments = append(machineDeployments, generateTestNodeMachineDeployments(cluster, ns, nodeDeploymentNames)...)
+	return machineDeployments
+}
+
+func generateValidExtractControlPlaneMachineDeploymentInput(cluster *clusterv1.Cluster, ns, controlPlaneName string, nodeDeploymentNames []string) []*clusterv1.MachineDeployment {
+	var machineDeployments []*clusterv1.MachineDeployment
+	machineDeployments = append(machineDeployments, generateTestControlPlaneMachineDeployment(cluster, ns, controlPlaneName))
+	machineDeployments = append(machineDeployments, generateTestNodeMachineDeployments(cluster, ns, nodeDeploymentNames)...)
+	return machineDeployments
 }
 
 func generateMachines(cluster *clusterv1.Cluster, ns string) []*clusterv1.Machine {
@@ -1520,11 +1622,14 @@ func generateMachines(cluster *clusterv1.Cluster, ns string) []*clusterv1.Machin
 
 func generateMachineDeployments(cluster *clusterv1.Cluster, ns string) []*clusterv1.MachineDeployment {
 	var machineDeployments []*clusterv1.MachineDeployment
-	deploymentName := "node-deployment"
+	controlPlaneName := "control-plane"
+	nodeDeploymentName := "node-deployment"
 	if cluster != nil {
-		deploymentName = cluster.Name + deploymentName
+		controlPlaneName = cluster.Name + controlPlaneName
+		nodeDeploymentName = cluster.Name + nodeDeploymentName
 	}
-	machineDeployments = append(machineDeployments, generateTestNodeMachineDeployment(cluster, ns, deploymentName))
+	machineDeployments = append(machineDeployments, generateTestControlPlaneMachineDeployment(cluster, ns, controlPlaneName))
+	machineDeployments = append(machineDeployments, generateTestNodeMachineDeployment(cluster, ns, nodeDeploymentName))
 	return machineDeployments
 }
 

--- a/cmd/clusterctl/cmd/alpha_phase_apply_machines.go
+++ b/cmd/clusterctl/cmd/alpha_phase_apply_machines.go
@@ -60,7 +60,12 @@ func RunAlphaPhaseApplyMachines(pamo *AlphaPhaseApplyMachinesOptions) error {
 		return err
 	}
 
-	machines, machineDeployments, err := util.ParseMachinesYaml(pamo.Machines)
+	machines, err := util.ParseMachinesYaml(pamo.Machines)
+	if err != nil {
+		return err
+	}
+
+	machineDeployments, err := util.ParseMachineDeploymentYaml(pamo.Machines)
 	if err != nil {
 		return err
 	}

--- a/cmd/clusterctl/cmd/alpha_phase_apply_machines.go
+++ b/cmd/clusterctl/cmd/alpha_phase_apply_machines.go
@@ -60,7 +60,7 @@ func RunAlphaPhaseApplyMachines(pamo *AlphaPhaseApplyMachinesOptions) error {
 		return err
 	}
 
-	machines, err := util.ParseMachinesYaml(pamo.Machines)
+	machines, machineDeployments, err := util.ParseMachinesYaml(pamo.Machines)
 	if err != nil {
 		return err
 	}
@@ -71,7 +71,7 @@ func RunAlphaPhaseApplyMachines(pamo *AlphaPhaseApplyMachinesOptions) error {
 		return errors.Wrap(err, "unable to create cluster client")
 	}
 
-	if err := phases.ApplyMachines(client, pamo.Namespace, machines); err != nil {
+	if err := phases.ApplyMachines(client, pamo.Namespace, machines, machineDeployments); err != nil {
 		return errors.Wrap(err, "unable to apply machines")
 	}
 

--- a/cmd/clusterctl/cmd/create_cluster.go
+++ b/cmd/clusterctl/cmd/create_cluster.go
@@ -68,7 +68,7 @@ func RunCreate(co *CreateOptions) error {
 	if err != nil {
 		return err
 	}
-	m, err := util.ParseMachinesYaml(co.Machine)
+	m, md, err := util.ParseMachinesYaml(co.Machine)
 	if err != nil {
 		return err
 	}
@@ -109,7 +109,7 @@ func RunCreate(co *CreateOptions) error {
 		string(bc),
 		co.BootstrapFlags.Cleanup)
 
-	return d.Create(c, m, pd, co.KubeconfigOutput, pcsFactory)
+	return d.Create(c, m, md, pd, co.KubeconfigOutput, pcsFactory)
 }
 
 func init() {

--- a/cmd/clusterctl/cmd/create_cluster.go
+++ b/cmd/clusterctl/cmd/create_cluster.go
@@ -68,7 +68,11 @@ func RunCreate(co *CreateOptions) error {
 	if err != nil {
 		return err
 	}
-	m, md, err := util.ParseMachinesYaml(co.Machine)
+	m, err := util.ParseMachinesYaml(co.Machine)
+	if err != nil {
+		return err
+	}
+	md, err := util.ParseMachineDeploymentYaml(co.Machine)
 	if err != nil {
 		return err
 	}

--- a/cmd/clusterctl/phases/applymachines.go
+++ b/cmd/clusterctl/phases/applymachines.go
@@ -23,7 +23,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
 
-func ApplyMachines(client clusterclient.Client, namespace string, machines []*clusterv1.Machine) error {
+func ApplyMachines(client clusterclient.Client, namespace string, machines []*clusterv1.Machine, machineDeployments []*clusterv1.MachineDeployment) error {
 	if namespace == "" {
 		namespace = client.GetContextNamespace()
 	}
@@ -35,6 +35,11 @@ func ApplyMachines(client clusterclient.Client, namespace string, machines []*cl
 
 	klog.Infof("Creating machines in namespace %q", namespace)
 	if err := client.CreateMachines(machines, namespace); err != nil {
+		return err
+	}
+
+	klog.Infof("Creating machinedeployments in namespace %q", namespace)
+	if err := client.CreateMachineDeployments(machineDeployments, namespace); err != nil {
 		return err
 	}
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -68,7 +68,7 @@ func RandomString(n int) string {
 // Deprecated: use GetControlPlaneMachines.
 func GetControlPlaneMachine(machines []*clusterv1.Machine) *clusterv1.Machine {
 	for _, machine := range machines {
-		if IsControlPlaneMachine(machine.Spec) {
+		if IsControlPlaneMachine(machine) {
 			return machine
 		}
 	}
@@ -78,7 +78,7 @@ func GetControlPlaneMachine(machines []*clusterv1.Machine) *clusterv1.Machine {
 // GetControlPlaneMachines returns a slice containing control plane machines.
 func GetControlPlaneMachines(machines []*clusterv1.Machine) (res []*clusterv1.Machine) {
 	for _, machine := range machines {
-		if IsControlPlaneMachine(machine.Spec) {
+		if IsControlPlaneMachine(machine) {
 			res = append(res, machine)
 		}
 	}
@@ -152,8 +152,13 @@ func GetMachineIfExists(c client.Client, namespace, name string) (*clusterv1.Mac
 }
 
 // IsControlPlaneMachine checks machine is a control plane node.
-func IsControlPlaneMachine(spec clusterv1.MachineSpec) bool {
-	return spec.Versions.ControlPlane != ""
+func IsControlPlaneMachine(machine *clusterv1.Machine) bool {
+	return machine.Spec.Versions.ControlPlane != ""
+}
+
+// IsControlPlaneMachineDeployment checks machinedeployment defines control plane nodes
+func IsControlPlaneMachineDeployment(machinedeployment *clusterv1.MachineDeployment) bool {
+	return machinedeployment.Spec.Template.Spec.Versions.ControlPlane != ""
 }
 
 // IsNodeReady returns true if a node is ready.

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -41,6 +41,18 @@ kind: Machine
 metadata:
   name: machine2`
 
+const validMachineDeployments1 = `
+---
+apiVersion: "cluster.k8s.io/v1alpha1"
+kind: MachineDeployment
+metadata:
+  name: machinedeployment1
+---
+apiVersion: "cluster.k8s.io/v1alpha1"
+kind: MachineDeployment
+metadata:
+  name: machinedeployment2`
+
 const validUnified1 = `
 apiVersion: "cluster.k8s.io/v1alpha1"
 kind: Cluster
@@ -69,7 +81,12 @@ metadata:
 apiVersion: "cluster.k8s.io/v1alpha1"
 kind: Machine
 metadata:
-  name: machine2`
+  name: machine2
+---
+apiVersion: "cluster.k8s.io/v1alpha1"
+kind: MachineDeployment
+metadata:
+  name: machinedeployment1`
 
 const validUnified3 = `
 apiVersion: v1
@@ -243,36 +260,47 @@ func TestParseClusterYaml(t *testing.T) {
 
 func TestParseMachineYaml(t *testing.T) {
 	t.Run("File does not exist", func(t *testing.T) {
-		_, err := ParseMachinesYaml("fileDoesNotExist")
+		_, _, err := ParseMachinesYaml("fileDoesNotExist")
 		if err == nil {
 			t.Fatal("Was able to parse a file that does not exist")
 		}
 	})
 	var testcases = []struct {
-		name                 string
-		contents             string
-		expectErr            bool
-		expectedMachineCount int
+		name                           string
+		contents                       string
+		expectErr                      bool
+		expectedMachineCount           int
+		expectedMachineDeploymentCount int
 	}{
 		{
-			name:                 "valid file using Machines",
-			contents:             validMachines1,
-			expectedMachineCount: 2,
+			name:                           "valid file using Machines",
+			contents:                       validMachines1,
+			expectedMachineCount:           2,
+			expectedMachineDeploymentCount: 0,
 		},
 		{
-			name:                 "valid unified file with machine list",
-			contents:             validUnified1,
-			expectedMachineCount: 1,
+			name:                           "valid file using MachineDeployments",
+			contents:                       validMachineDeployments1,
+			expectedMachineCount:           0,
+			expectedMachineDeploymentCount: 2,
 		},
 		{
-			name:                 "valid unified file with separate machines",
-			contents:             validUnified2,
-			expectedMachineCount: 2,
+			name:                           "valid unified file with machine list",
+			contents:                       validUnified1,
+			expectedMachineCount:           1,
+			expectedMachineDeploymentCount: 0,
 		},
 		{
-			name:                 "valid unified file with separate machines and a configmap",
-			contents:             validUnified3,
-			expectedMachineCount: 2,
+			name:                           "valid unified file with separate machines",
+			contents:                       validUnified2,
+			expectedMachineCount:           2,
+			expectedMachineDeploymentCount: 1,
+		},
+		{
+			name:                           "valid unified file with separate machines and a configmap",
+			contents:                       validUnified3,
+			expectedMachineCount:           2,
+			expectedMachineDeploymentCount: 0,
 		},
 		{
 			name:      "invalid file using MachineList",
@@ -308,7 +336,7 @@ func TestParseMachineYaml(t *testing.T) {
 			}
 			defer os.Remove(file)
 
-			m, err := ParseMachinesYaml(file)
+			m, md, err := ParseMachinesYaml(file)
 			if (testcase.expectErr && err == nil) || (!testcase.expectErr && err != nil) {
 				t.Fatalf("Unexpected returned error. Got: %v, Want Err: %v", err, testcase.expectErr)
 			}
@@ -320,6 +348,9 @@ func TestParseMachineYaml(t *testing.T) {
 			}
 			if len(m) != testcase.expectedMachineCount {
 				t.Fatalf("Unexpected machine count. Got: %v, Want: %v", len(m), testcase.expectedMachineCount)
+			}
+			if len(md) != testcase.expectedMachineDeploymentCount {
+				t.Fatalf("Unexpected machinedeployment count. Got: %v, Want: %v", len(m), testcase.expectedMachineDeploymentCount)
 			}
 		})
 	}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -260,47 +260,41 @@ func TestParseClusterYaml(t *testing.T) {
 
 func TestParseMachineYaml(t *testing.T) {
 	t.Run("File does not exist", func(t *testing.T) {
-		_, _, err := ParseMachinesYaml("fileDoesNotExist")
+		_, err := ParseMachinesYaml("fileDoesNotExist")
 		if err == nil {
 			t.Fatal("Was able to parse a file that does not exist")
 		}
 	})
 	var testcases = []struct {
-		name                           string
-		contents                       string
-		expectErr                      bool
-		expectedMachineCount           int
-		expectedMachineDeploymentCount int
+		name                 string
+		contents             string
+		expectErr            bool
+		expectedMachineCount int
 	}{
 		{
-			name:                           "valid file using Machines",
-			contents:                       validMachines1,
-			expectedMachineCount:           2,
-			expectedMachineDeploymentCount: 0,
+			name:                 "valid file using Machines",
+			contents:             validMachines1,
+			expectedMachineCount: 2,
 		},
 		{
-			name:                           "valid file using MachineDeployments",
-			contents:                       validMachineDeployments1,
-			expectedMachineCount:           0,
-			expectedMachineDeploymentCount: 2,
+			name:                 "valid file using MachineDeployments",
+			contents:             validMachineDeployments1,
+			expectedMachineCount: 0,
 		},
 		{
-			name:                           "valid unified file with machine list",
-			contents:                       validUnified1,
-			expectedMachineCount:           1,
-			expectedMachineDeploymentCount: 0,
+			name:                 "valid unified file with machine list",
+			contents:             validUnified1,
+			expectedMachineCount: 1,
 		},
 		{
-			name:                           "valid unified file with separate machines",
-			contents:                       validUnified2,
-			expectedMachineCount:           2,
-			expectedMachineDeploymentCount: 1,
+			name:                 "valid unified file with separate machines",
+			contents:             validUnified2,
+			expectedMachineCount: 2,
 		},
 		{
-			name:                           "valid unified file with separate machines and a configmap",
-			contents:                       validUnified3,
-			expectedMachineCount:           2,
-			expectedMachineDeploymentCount: 0,
+			name:                 "valid unified file with separate machines and a configmap",
+			contents:             validUnified3,
+			expectedMachineCount: 2,
 		},
 		{
 			name:      "invalid file using MachineList",
@@ -336,7 +330,7 @@ func TestParseMachineYaml(t *testing.T) {
 			}
 			defer os.Remove(file)
 
-			m, md, err := ParseMachinesYaml(file)
+			m, err := ParseMachinesYaml(file)
 			if (testcase.expectErr && err == nil) || (!testcase.expectErr && err != nil) {
 				t.Fatalf("Unexpected returned error. Got: %v, Want Err: %v", err, testcase.expectErr)
 			}
@@ -349,8 +343,59 @@ func TestParseMachineYaml(t *testing.T) {
 			if len(m) != testcase.expectedMachineCount {
 				t.Fatalf("Unexpected machine count. Got: %v, Want: %v", len(m), testcase.expectedMachineCount)
 			}
+		})
+	}
+}
+
+func TestParseMachineDeploymentYaml(t *testing.T) {
+	t.Run("File does not exist", func(t *testing.T) {
+		_, err := ParseMachineDeploymentYaml("fileDoesNotExist")
+		if err == nil {
+			t.Fatal("Was able to parse a file that does not exist")
+		}
+	})
+	var testcases = []struct {
+		name                           string
+		contents                       string
+		expectErr                      bool
+		expectedMachineDeploymentCount int
+	}{
+		{
+			name:                           "valid file using MachineDeployments",
+			contents:                       validMachineDeployments1,
+			expectedMachineDeploymentCount: 2,
+		},
+		{
+			name:                           "valid unified file with separate machines",
+			contents:                       validUnified2,
+			expectedMachineDeploymentCount: 1,
+		},
+		{
+			name:      "gibberish in file",
+			contents:  `!@#blah ` + validMachines1 + ` blah!@#`,
+			expectErr: true,
+		},
+	}
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			file, err := createTempFile(testcase.contents)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.Remove(file)
+
+			md, err := ParseMachineDeploymentYaml(file)
+			if (testcase.expectErr && err == nil) || (!testcase.expectErr && err != nil) {
+				t.Fatalf("Unexpected returned error. Got: %v, Want Err: %v", err, testcase.expectErr)
+			}
+			if err != nil {
+				return
+			}
+			if md == nil {
+				t.Fatalf("No machinedeployments returned in success case.")
+			}
 			if len(md) != testcase.expectedMachineDeploymentCount {
-				t.Fatalf("Unexpected machinedeployment count. Got: %v, Want: %v", len(m), testcase.expectedMachineDeploymentCount)
+				t.Fatalf("Unexpected machinedeployment count. Got: %v, Want: %v", len(md), testcase.expectedMachineDeploymentCount)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

The `apply-machines` phase will now detect and apply MachineDeployments as nodes, and therefore, so will `clusterctl create cluster`.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support MachineDeployments as part of the apply-machines phase
```
