### PR TITLE
✨ New MachinePool spec.externallyManagedReplicaCount

### DIFF
--- a/config/crd/bases/exp.cluster.x-k8s.io_machinepools.yaml
+++ b/config/crd/bases/exp.cluster.x-k8s.io_machinepools.yaml
@@ -386,7 +386,6 @@ spec:
                 type: object
             required:
             - clusterName
-            - externallyManagedReplicaCount
             - template
             type: object
           status:

--- a/config/crd/bases/exp.cluster.x-k8s.io_machinepools.yaml
+++ b/config/crd/bases/exp.cluster.x-k8s.io_machinepools.yaml
@@ -60,7 +60,7 @@ spec:
                 minLength: 1
                 type: string
               externallyManagedReplicaCount:
-                description: Wether the Replicas value is externally managed.
+                description: Whether the Replicas value is externally managed.
                 type: boolean
               failureDomains:
                 description: FailureDomains is the list of failure domains this MachinePool

--- a/config/crd/bases/exp.cluster.x-k8s.io_machinepools.yaml
+++ b/config/crd/bases/exp.cluster.x-k8s.io_machinepools.yaml
@@ -59,6 +59,9 @@ spec:
                   to.
                 minLength: 1
                 type: string
+              externallyManagedReplicaCount:
+                description: Wether the Replicas value is externally managed.
+                type: boolean
               failureDomains:
                 description: FailureDomains is the list of failure domains this MachinePool
                   should be attached to.
@@ -383,6 +386,7 @@ spec:
                 type: object
             required:
             - clusterName
+            - externallyManagedReplicaCount
             - template
             type: object
           status:

--- a/exp/api/v1alpha3/machinepool_types.go
+++ b/exp/api/v1alpha3/machinepool_types.go
@@ -63,7 +63,7 @@ type MachinePoolSpec struct {
 	// FailureDomains is the list of failure domains this MachinePool should be attached to.
 	FailureDomains []string `json:"failureDomains,omitempty"`
 
-	// Wether the Replicas value is externally managed.
+	// Whether the Replicas value is externally managed.
 	ExternallyManagedReplicaCount bool `json:"externallyManagedReplicaCount,omitempty"`
 }
 

--- a/exp/api/v1alpha3/machinepool_types.go
+++ b/exp/api/v1alpha3/machinepool_types.go
@@ -64,7 +64,8 @@ type MachinePoolSpec struct {
 	FailureDomains []string `json:"failureDomains,omitempty"`
 
 	// Whether the Replicas value is externally managed.
-	ExternallyManagedReplicaCount bool `json:"externallyManagedReplicaCount,omitempty"`
+	// +optional
+	ExternallyManagedReplicaCount bool `json:"externallyManagedReplicaCount"`
 }
 
 // ANCHOR_END: MachinePoolSpec

--- a/exp/api/v1alpha3/machinepool_types.go
+++ b/exp/api/v1alpha3/machinepool_types.go
@@ -62,6 +62,9 @@ type MachinePoolSpec struct {
 
 	// FailureDomains is the list of failure domains this MachinePool should be attached to.
 	FailureDomains []string `json:"failureDomains,omitempty"`
+
+	// Wether the Replicas value is externally managed.
+	ExternallyManagedReplicaCount bool `json:"externallyManagedReplicaCount"`
 }
 
 // ANCHOR_END: MachinePoolSpec

--- a/exp/api/v1alpha3/machinepool_types.go
+++ b/exp/api/v1alpha3/machinepool_types.go
@@ -64,7 +64,7 @@ type MachinePoolSpec struct {
 	FailureDomains []string `json:"failureDomains,omitempty"`
 
 	// Wether the Replicas value is externally managed.
-	ExternallyManagedReplicaCount bool `json:"externallyManagedReplicaCount"`
+	ExternallyManagedReplicaCount bool `json:"externallyManagedReplicaCount,omitempty"`
 }
 
 // ANCHOR_END: MachinePoolSpec

--- a/exp/controllers/machinepool_controller_noderef.go
+++ b/exp/controllers/machinepool_controller_noderef.go
@@ -53,7 +53,9 @@ func (r *MachinePoolReconciler) reconcileNodeRefs(ctx context.Context, cluster *
 	}
 
 	// Check that the Machine doesn't already have a NodeRefs.
-	if mp.Status.Replicas == mp.Status.ReadyReplicas && len(mp.Status.NodeRefs) == int(mp.Status.ReadyReplicas) {
+	if mp.Status.Replicas == mp.Status.ReadyReplicas &&
+		len(mp.Status.NodeRefs) == int(mp.Status.ReadyReplicas) &&
+		mp.Status.UnavailableReplicas == mp.Status.Replicas-mp.Status.AvailableReplicas {
 		conditions.MarkTrue(mp, expv1.ReplicasReadyCondition)
 		return ctrl.Result{}, nil
 	}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
- Adds a new `spec.externallyManagedReplicaCount` field to `MachinePool` to notify the infrastructure provider that it is expected to set the MachinePool `spec.replicas` value.
- Makes sure `UnavailableReplicas` is properly computed when the infrastructure provider manages `spec.replicas`.
