### PR TITLE
:bug: MachinePool noderefs should use full provider ID for uniqueness

### DIFF
--- a/exp/internal/controllers/machinepool_controller_noderef.go
+++ b/exp/internal/controllers/machinepool_controller_noderef.go
@@ -221,7 +221,7 @@ func (r *MachinePoolReconciler) getNodeReferences(ctx context.Context, c client.
 		}
 	}
 
-	if len(nodeRefs) == 0 {
+	if len(nodeRefs) == 0 && len(providerIDList) != 0 {
 		return getNodeReferencesResult{}, errNoAvailableNodes
 	}
 	return getNodeReferencesResult{nodeRefs, available, ready}, nil

--- a/exp/internal/controllers/machinepool_controller_noderef.go
+++ b/exp/internal/controllers/machinepool_controller_noderef.go
@@ -156,7 +156,7 @@ func (r *MachinePoolReconciler) deleteRetiredNodes(ctx context.Context, c client
 			continue
 		}
 
-		nodeRefsMap[nodeProviderID.ID()] = node
+		nodeRefsMap[nodeProviderID.String()] = node
 	}
 	for _, providerID := range providerIDList {
 		pid, err := noderefutil.NewProviderID(providerID)
@@ -164,7 +164,7 @@ func (r *MachinePoolReconciler) deleteRetiredNodes(ctx context.Context, c client
 			log.V(2).Info("Failed to parse ProviderID, skipping", "err", err, "providerID", providerID)
 			continue
 		}
-		delete(nodeRefsMap, pid.ID())
+		delete(nodeRefsMap, pid.String())
 	}
 	for _, node := range nodeRefsMap {
 		if err := c.Delete(ctx, node); err != nil {
@@ -192,7 +192,7 @@ func (r *MachinePoolReconciler) getNodeReferences(ctx context.Context, c client.
 				continue
 			}
 
-			nodeRefsMap[nodeProviderID.ID()] = node
+			nodeRefsMap[nodeProviderID.String()] = node
 		}
 
 		if nodeList.Continue == "" {
@@ -207,7 +207,7 @@ func (r *MachinePoolReconciler) getNodeReferences(ctx context.Context, c client.
 			log.V(2).Info("Failed to parse ProviderID, skipping", "err", err, "providerID", providerID)
 			continue
 		}
-		if node, ok := nodeRefsMap[pid.ID()]; ok {
+		if node, ok := nodeRefsMap[pid.String()]; ok {
 			available++
 			if nodeIsReady(&node) {
 				ready++

--- a/exp/internal/controllers/machinepool_controller_noderef_test.go
+++ b/exp/internal/controllers/machinepool_controller_noderef_test.go
@@ -66,6 +66,22 @@ func TestMachinePoolGetNodeReference(t *testing.T) {
 				ProviderID: "azure://westus2/id-node-4",
 			},
 		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "azure-nodepool1-0",
+			},
+			Spec: corev1.NodeSpec{
+				ProviderID: "azure://westus2/id-nodepool1/0",
+			},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "azure-nodepool2-0",
+			},
+			Spec: corev1.NodeSpec{
+				ProviderID: "azure://westus2/id-nodepool2/0",
+			},
+		},
 	}
 
 	client := fake.NewClientBuilder().WithObjects(nodeList...).Build()
@@ -135,6 +151,25 @@ func TestMachinePoolGetNodeReference(t *testing.T) {
 				references: []corev1.ObjectReference{},
 				available:  0,
 				ready:      0,
+			},
+		},
+		{
+			name:           "valid provider id with non-unique instance id, valid azure node",
+			providerIDList: []string{"azure://westus2/id-nodepool1/0"},
+			expected: &getNodeReferencesResult{
+				references: []corev1.ObjectReference{
+					{Name: "azure-nodepool1-0"},
+				},
+			},
+		},
+		{
+			name:           "valid provider ids with same instance ids, valid azure nodes",
+			providerIDList: []string{"azure://westus2/id-nodepool1/0", "azure://westus2/id-nodepool2/0"},
+			expected: &getNodeReferencesResult{
+				references: []corev1.ObjectReference{
+					{Name: "azure-nodepool1-0"},
+					{Name: "azure-nodepool2-0"},
+				},
 			},
 		},
 	}

--- a/exp/internal/controllers/machinepool_controller_noderef_test.go
+++ b/exp/internal/controllers/machinepool_controller_noderef_test.go
@@ -128,6 +128,15 @@ func TestMachinePoolGetNodeReference(t *testing.T) {
 			expected:       nil,
 			err:            errNoAvailableNodes,
 		},
+		{
+			name:           "no provider id, no node found",
+			providerIDList: []string{},
+			expected: &getNodeReferencesResult{
+				references: []corev1.ObjectReference{},
+				available:  0,
+				ready:      0,
+			},
+		},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
:bug: MachinePool noderefs should use full provider ID for uniqueness

fix: no nodeRefs when empty providerIDList is ok

This fixes MachinePool reconciliation when an empty providerIDList is
given. Previously it would always return an error in this case,
preventing the MachinePool readyReplicas etc. to go to 0.