### PR TITLE
 🐛 don't set replicas when externally managed

### DIFF
--- a/api/v1alpha3/zz_generated.conversion.go
+++ b/api/v1alpha3/zz_generated.conversion.go
@@ -29,6 +29,7 @@ import (
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	intstr "k8s.io/apimachinery/pkg/util/intstr"
+
 	v1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	errors "sigs.k8s.io/cluster-api/errors"
 )

--- a/api/v1alpha3/zz_generated.deepcopy.go
+++ b/api/v1alpha3/zz_generated.deepcopy.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
 	"sigs.k8s.io/cluster-api/errors"
 )
 

--- a/api/v1alpha4/zz_generated.conversion.go
+++ b/api/v1alpha4/zz_generated.conversion.go
@@ -29,6 +29,7 @@ import (
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	intstr "k8s.io/apimachinery/pkg/util/intstr"
+
 	v1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	errors "sigs.k8s.io/cluster-api/errors"
 )

--- a/api/v1alpha4/zz_generated.deepcopy.go
+++ b/api/v1alpha4/zz_generated.deepcopy.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
 	"sigs.k8s.io/cluster-api/errors"
 )
 

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
 	"sigs.k8s.io/cluster-api/errors"
 )
 

--- a/bootstrap/kubeadm/api/v1alpha3/zz_generated.conversion.go
+++ b/bootstrap/kubeadm/api/v1alpha3/zz_generated.conversion.go
@@ -26,6 +26,7 @@ import (
 
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+
 	apiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	apiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	v1beta1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"

--- a/bootstrap/kubeadm/api/v1alpha3/zz_generated.deepcopy.go
+++ b/bootstrap/kubeadm/api/v1alpha3/zz_generated.deepcopy.go
@@ -23,6 +23,7 @@ package v1alpha3
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
+
 	apiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/bootstrap/kubeadm/types/upstreamv1beta1"
 )

--- a/bootstrap/kubeadm/api/v1alpha4/zz_generated.conversion.go
+++ b/bootstrap/kubeadm/api/v1alpha4/zz_generated.conversion.go
@@ -28,6 +28,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+
 	apiv1alpha4 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	apiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	v1beta1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"

--- a/bootstrap/kubeadm/api/v1alpha4/zz_generated.deepcopy.go
+++ b/bootstrap/kubeadm/api/v1alpha4/zz_generated.deepcopy.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
 	apiv1alpha4 "sigs.k8s.io/cluster-api/api/v1alpha4"
 )
 

--- a/bootstrap/kubeadm/api/v1beta1/zz_generated.deepcopy.go
+++ b/bootstrap/kubeadm/api/v1beta1/zz_generated.deepcopy.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
 	apiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 

--- a/bootstrap/kubeadm/types/upstreamv1beta1/zz_generated.conversion.go
+++ b/bootstrap/kubeadm/types/upstreamv1beta1/zz_generated.conversion.go
@@ -28,6 +28,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+
 	v1beta1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 )
 

--- a/bootstrap/kubeadm/types/upstreamv1beta2/zz_generated.conversion.go
+++ b/bootstrap/kubeadm/types/upstreamv1beta2/zz_generated.conversion.go
@@ -28,6 +28,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+
 	v1beta1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 )
 

--- a/bootstrap/kubeadm/types/upstreamv1beta3/zz_generated.conversion.go
+++ b/bootstrap/kubeadm/types/upstreamv1beta3/zz_generated.conversion.go
@@ -28,6 +28,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+
 	v1beta1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 )
 

--- a/controlplane/kubeadm/api/v1alpha3/zz_generated.conversion.go
+++ b/controlplane/kubeadm/api/v1alpha3/zz_generated.conversion.go
@@ -27,6 +27,7 @@ import (
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	intstr "k8s.io/apimachinery/pkg/util/intstr"
+
 	clusterapiapiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	apiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	apiv1alpha3 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha3"

--- a/controlplane/kubeadm/api/v1alpha3/zz_generated.deepcopy.go
+++ b/controlplane/kubeadm/api/v1alpha3/zz_generated.deepcopy.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
 	apiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 )
 

--- a/controlplane/kubeadm/api/v1alpha4/zz_generated.conversion.go
+++ b/controlplane/kubeadm/api/v1alpha4/zz_generated.conversion.go
@@ -28,6 +28,7 @@ import (
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	intstr "k8s.io/apimachinery/pkg/util/intstr"
+
 	apiv1alpha4 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	apiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	kubeadmapiv1alpha4 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha4"

--- a/controlplane/kubeadm/api/v1alpha4/zz_generated.deepcopy.go
+++ b/controlplane/kubeadm/api/v1alpha4/zz_generated.deepcopy.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
 	apiv1alpha4 "sigs.k8s.io/cluster-api/api/v1alpha4"
 )
 

--- a/controlplane/kubeadm/api/v1beta1/zz_generated.deepcopy.go
+++ b/controlplane/kubeadm/api/v1beta1/zz_generated.deepcopy.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
 	apiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 

--- a/exp/addons/api/v1alpha3/zz_generated.conversion.go
+++ b/exp/addons/api/v1alpha3/zz_generated.conversion.go
@@ -27,6 +27,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+
 	apiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	apiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	v1beta1 "sigs.k8s.io/cluster-api/exp/addons/api/v1beta1"

--- a/exp/addons/api/v1alpha3/zz_generated.deepcopy.go
+++ b/exp/addons/api/v1alpha3/zz_generated.deepcopy.go
@@ -23,6 +23,7 @@ package v1alpha3
 
 import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
+
 	apiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 )
 

--- a/exp/addons/api/v1alpha4/zz_generated.conversion.go
+++ b/exp/addons/api/v1alpha4/zz_generated.conversion.go
@@ -27,6 +27,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+
 	apiv1alpha4 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	apiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	v1beta1 "sigs.k8s.io/cluster-api/exp/addons/api/v1beta1"

--- a/exp/addons/api/v1alpha4/zz_generated.deepcopy.go
+++ b/exp/addons/api/v1alpha4/zz_generated.deepcopy.go
@@ -23,6 +23,7 @@ package v1alpha4
 
 import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
+
 	apiv1alpha4 "sigs.k8s.io/cluster-api/api/v1alpha4"
 )
 

--- a/exp/addons/api/v1beta1/zz_generated.deepcopy.go
+++ b/exp/addons/api/v1beta1/zz_generated.deepcopy.go
@@ -23,6 +23,7 @@ package v1beta1
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
+
 	apiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 

--- a/exp/api/v1alpha3/zz_generated.conversion.go
+++ b/exp/api/v1alpha3/zz_generated.conversion.go
@@ -27,6 +27,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+
 	apiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	apiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	errors "sigs.k8s.io/cluster-api/errors"

--- a/exp/api/v1alpha3/zz_generated.deepcopy.go
+++ b/exp/api/v1alpha3/zz_generated.deepcopy.go
@@ -24,6 +24,7 @@ package v1alpha3
 import (
 	"k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+
 	apiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/errors"
 )

--- a/exp/api/v1alpha4/zz_generated.conversion.go
+++ b/exp/api/v1alpha4/zz_generated.conversion.go
@@ -27,6 +27,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+
 	apiv1alpha4 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	apiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	errors "sigs.k8s.io/cluster-api/errors"

--- a/exp/api/v1alpha4/zz_generated.deepcopy.go
+++ b/exp/api/v1alpha4/zz_generated.deepcopy.go
@@ -24,6 +24,7 @@ package v1alpha4
 import (
 	"k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+
 	apiv1alpha4 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/errors"
 )

--- a/exp/api/v1beta1/machinepool_types.go
+++ b/exp/api/v1beta1/machinepool_types.go
@@ -37,7 +37,7 @@ type MachinePoolSpec struct {
 	// +kubebuilder:validation:MinLength=1
 	ClusterName string `json:"clusterName"`
 
-	// Number of desired machines. Defaults to 1.
+	// Number of desired machines. Defaults to 1 unless the MachinePool is externally managed.
 	// This is a pointer to distinguish between explicit zero and not specified.
 	// +optional
 	Replicas *int32 `json:"replicas,omitempty"`

--- a/exp/api/v1beta1/machinepool_webhook.go
+++ b/exp/api/v1beta1/machinepool_webhook.go
@@ -18,6 +18,7 @@ package v1beta1
 
 import (
 	"fmt"
+	"sigs.k8s.io/cluster-api/util/annotations"
 	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -51,7 +52,7 @@ func (m *MachinePool) Default() {
 	}
 	m.Labels[clusterv1.ClusterLabelName] = m.Spec.ClusterName
 
-	if m.Spec.Replicas == nil {
+	if m.Spec.Replicas == nil && !annotations.IsExternallyManaged(m) {
 		m.Spec.Replicas = pointer.Int32Ptr(1)
 	}
 

--- a/exp/api/v1beta1/machinepool_webhook.go
+++ b/exp/api/v1beta1/machinepool_webhook.go
@@ -18,7 +18,6 @@ package v1beta1
 
 import (
 	"fmt"
-	"sigs.k8s.io/cluster-api/util/annotations"
 	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -30,6 +29,7 @@ import (
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/feature"
+	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/version"
 )
 

--- a/exp/api/v1beta1/zz_generated.deepcopy.go
+++ b/exp/api/v1beta1/zz_generated.deepcopy.go
@@ -24,6 +24,7 @@ package v1beta1
 import (
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
 	apiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/errors"
 )

--- a/exp/ipam/api/v1alpha1/zz_generated.deepcopy.go
+++ b/exp/ipam/api/v1alpha1/zz_generated.deepcopy.go
@@ -23,6 +23,7 @@ package v1alpha1
 
 import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
+
 	"sigs.k8s.io/cluster-api/api/v1beta1"
 )
 

--- a/exp/runtime/api/v1alpha1/zz_generated.deepcopy.go
+++ b/exp/runtime/api/v1alpha1/zz_generated.deepcopy.go
@@ -24,6 +24,7 @@ package v1alpha1
 import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+
 	"sigs.k8s.io/cluster-api/api/v1beta1"
 )
 

--- a/internal/runtime/test/v1alpha1/zz_generated.conversion.go
+++ b/internal/runtime/test/v1alpha1/zz_generated.conversion.go
@@ -24,6 +24,7 @@ package v1alpha1
 import (
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+
 	v1alpha4 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	v1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	v1alpha2 "sigs.k8s.io/cluster-api/internal/runtime/test/v1alpha2"

--- a/internal/test/builder/zz_generated.deepcopy.go
+++ b/internal/test/builder/zz_generated.deepcopy.go
@@ -24,6 +24,7 @@ package builder
 import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
 	"sigs.k8s.io/cluster-api/api/v1beta1"
 	apiv1beta1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 )

--- a/test/infrastructure/docker/api/v1alpha3/zz_generated.conversion.go
+++ b/test/infrastructure/docker/api/v1alpha3/zz_generated.conversion.go
@@ -26,6 +26,7 @@ import (
 
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+
 	apiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	apiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	v1beta1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"

--- a/test/infrastructure/docker/api/v1alpha3/zz_generated.deepcopy.go
+++ b/test/infrastructure/docker/api/v1alpha3/zz_generated.deepcopy.go
@@ -23,6 +23,7 @@ package v1alpha3
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
+
 	apiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 )
 

--- a/test/infrastructure/docker/api/v1alpha4/zz_generated.conversion.go
+++ b/test/infrastructure/docker/api/v1alpha4/zz_generated.conversion.go
@@ -26,6 +26,7 @@ import (
 
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+
 	apiv1alpha4 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	apiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	v1beta1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"

--- a/test/infrastructure/docker/api/v1alpha4/zz_generated.deepcopy.go
+++ b/test/infrastructure/docker/api/v1alpha4/zz_generated.deepcopy.go
@@ -23,6 +23,7 @@ package v1alpha4
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
+
 	apiv1alpha4 "sigs.k8s.io/cluster-api/api/v1alpha4"
 )
 

--- a/test/infrastructure/docker/api/v1beta1/zz_generated.deepcopy.go
+++ b/test/infrastructure/docker/api/v1beta1/zz_generated.deepcopy.go
@@ -23,6 +23,7 @@ package v1beta1
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
+
 	apiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 

--- a/test/infrastructure/docker/exp/api/v1alpha3/zz_generated.conversion.go
+++ b/test/infrastructure/docker/exp/api/v1alpha3/zz_generated.conversion.go
@@ -26,6 +26,7 @@ import (
 
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+
 	apiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	apiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	dockerapiv1alpha3 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1alpha3"

--- a/test/infrastructure/docker/exp/api/v1alpha3/zz_generated.deepcopy.go
+++ b/test/infrastructure/docker/exp/api/v1alpha3/zz_generated.deepcopy.go
@@ -23,6 +23,7 @@ package v1alpha3
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
+
 	cluster_apiapiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	apiv1alpha3 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1alpha3"
 )

--- a/test/infrastructure/docker/exp/api/v1alpha4/zz_generated.conversion.go
+++ b/test/infrastructure/docker/exp/api/v1alpha4/zz_generated.conversion.go
@@ -26,6 +26,7 @@ import (
 
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+
 	apiv1alpha4 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	apiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	dockerapiv1alpha4 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1alpha4"

--- a/test/infrastructure/docker/exp/api/v1alpha4/zz_generated.deepcopy.go
+++ b/test/infrastructure/docker/exp/api/v1alpha4/zz_generated.deepcopy.go
@@ -23,6 +23,7 @@ package v1alpha4
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
+
 	cluster_apiapiv1alpha4 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	apiv1alpha4 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1alpha4"
 )

--- a/test/infrastructure/docker/exp/api/v1beta1/zz_generated.deepcopy.go
+++ b/test/infrastructure/docker/exp/api/v1beta1/zz_generated.deepcopy.go
@@ -23,6 +23,7 @@ package v1beta1
 
 import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
+
 	cluster_apiapiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	apiv1beta1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
When replica count is externally managed we don't want a default value here